### PR TITLE
Update CI actions to maintained alternatives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,42 +11,30 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo check
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell/actions/setup@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy


### PR DESCRIPTION
## Summary

- `haskell/actions/setup` → `haskell-actions/setup` (org renamed, fixes deprecation warning)
- `actions-rs/toolchain` → `dtolnay/rust-toolchain` (`actions-rs` org is archived)
- `actions-rs/cargo` → plain `run: cargo ...` (`actions-rs` org is archived)
- `actions/checkout` v3 → v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)