### PR TITLE
Add CHANGELOG and update README for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## [0.2.0] - 2026/03/14
+
+### Breaking changes
+
+- `eval()` now returns `Result<String>` (stdout only) and returns `Err(GhciError::EvalError { .. })` when ghci produces stderr. Use `eval_raw()` to get both stdout and stderr as before.
+- New error variants: `EvalError`, `HaskellParse`, `DisallowedInput`.
+- `~/.ghci` is now ignored by default to ensure a consistent prompt. Pass `-ghci-script` via `GhciBuilder` if needed.
+
+### Migration from 0.1.0
+
+```rust
+// 0.1.0
+let out = ghci.eval("1 + 1")?;        // out: EvalOutput
+println!("{}", out.stdout);
+
+// 0.2.0
+let out = ghci.eval("1 + 1")?;        // out: String
+println!("{}", out);
+
+// To get both stdout and stderr (old behaviour):
+let out = ghci.eval_raw("1 + 1")?;    // out: EvalOutput
+println!("{} {}", out.stdout, out.stderr);
+```
+
+### Added
+
+- `GhciBuilder` for configuring ghci path, arguments, and working directory.
+- `eval_raw()` for getting both stdout and stderr without error on stderr.
+- `eval_as::<T>()` for evaluating and parsing results via `FromHaskell`.
+- `ToHaskell` / `FromHaskell` traits for converting between Rust values and Haskell expressions (primitives, `Option`, `Vec`, tuples, records, constructor applications).
+- `SharedGhci` for sharing a session across threads (useful for test suites).
+- Deadline-based eval timeout.
+- `:set prompt` input rejection to prevent prompt desync.
+
+## [0.1.0] - 2023
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # ghci [![CI Status](https://github.com/basile-henry/ghci-rs/workflows/CI/badge.svg)](https://github.com/basile-henry/ghci-rs/actions) [![crates.io](https://img.shields.io/crates/v/ghci.svg)](https://crates.io/crates/ghci) [![docs.rs](https://docs.rs/ghci/badge.svg)](https://docs.rs/ghci)
 
+A crate to manage and communicate with `ghci` sessions.
 
- A crate to manage and communicate with `ghci` sessions
+```rust
+let mut ghci = Ghci::new()?;
+let out = ghci.eval("putStrLn \"Hello world\"")?;
+assert_eq!(out, "Hello world\n");
+```
 
- ```rust
- let mut ghci = Ghci::new()?;
- let out = ghci.eval("putStrLn \"Hello world\"")?;
- assert_eq!(&out.stdout, "Hello world\n");
- ```
+See the [docs](https://docs.rs/ghci) for more.
+
+> **Platform support:** Unix only (Linux, macOS, BSDs).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Updates README example to use `putStrLn "Hello world"` (matching the 0.1.0 docs) and adds a link to docs.rs
- Adds CHANGELOG with 0.2.0 migration guide covering the `eval()` return type change and new features (`GhciBuilder`, `eval_raw`, `ToHaskell`/`FromHaskell`, `SharedGhci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)