### PR TITLE
Fix CI workflow branch name and remove unused release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
-  release:
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
## Summary

- Fix `master` → `main` branch trigger so CI runs on main branch pushes
- Remove unused `release:` trigger (publishing is done manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)