### PR TITLE
Add ghci-derive crate with ToHaskell/FromHaskell derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "ghci-derive"]
+
 [package]
 name = "ghci"
 version = "0.2.0"
@@ -9,10 +12,18 @@ description = "Manage and communicate with ghci (Haskell's GHC interpreter)"
 keywords = ["haskell", "repl", "subprocess", "ffi"]
 categories = ["compilers", "development-tools"]
 
+[features]
+derive = ["dep:ghci-derive"]
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["poll"], default-features = false }
 nonblock = "0.2"
 thiserror = "2"
+ghci-derive = { version = "0.2.0", path = "ghci-derive", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
+
+[[test]]
+name = "derive"
+required-features = ["derive"]

--- a/ghci-derive/Cargo.toml
+++ b/ghci-derive/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Basile Henry <bjm.henry@gmail.com>"]
 license = "MIT"
 edition = "2021"
 description = "Derive macros for ghci ToHaskell/FromHaskell traits"
+readme = "../README.md"
+keywords = ["haskell", "repl", "subprocess", "ffi"]
+categories = ["compilers", "development-tools"]
 
 [lib]
 proc-macro = true

--- a/ghci-derive/Cargo.toml
+++ b/ghci-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ghci-derive"
+version = "0.2.0"
+repository = "https://github.com/basile-henry/ghci-rs"
+authors = ["Basile Henry <bjm.henry@gmail.com>"]
+license = "MIT"
+edition = "2021"
+description = "Derive macros for ghci ToHaskell/FromHaskell traits"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/ghci-derive/src/lib.rs
+++ b/ghci-derive/src/lib.rs
@@ -1,0 +1,653 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, GenericParam, LitStr};
+
+#[derive(Clone, Copy, PartialEq)]
+enum Style {
+    App,
+    Record,
+}
+
+struct HaskellAttrs {
+    name: Option<String>,
+    transparent: bool,
+    style: Option<Style>,
+    skip: bool,
+    bound_to: Option<String>,
+    bound_from: Option<String>,
+}
+
+fn parse_haskell_attrs(attrs: &[syn::Attribute]) -> HaskellAttrs {
+    let mut name = None;
+    let mut transparent = false;
+    let mut style = None;
+    let mut skip = false;
+    let mut bound_to = None;
+    let mut bound_from = None;
+    for attr in attrs {
+        if attr.path().is_ident("haskell") {
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("name") {
+                    let value = meta.value()?;
+                    let s: LitStr = value.parse()?;
+                    name = Some(s.value());
+                } else if meta.path.is_ident("transparent") {
+                    transparent = true;
+                } else if meta.path.is_ident("style") {
+                    let value = meta.value()?;
+                    let s: LitStr = value.parse()?;
+                    match s.value().as_str() {
+                        "app" => style = Some(Style::App),
+                        "record" => style = Some(Style::Record),
+                        _ => {
+                            return Err(meta.error("expected \"app\" or \"record\""));
+                        }
+                    }
+                } else if meta.path.is_ident("skip") {
+                    skip = true;
+                } else if meta.path.is_ident("bound") {
+                    meta.parse_nested_meta(|inner| {
+                        if inner.path.is_ident("ToHaskell") {
+                            let value = inner.value()?;
+                            let s: LitStr = value.parse()?;
+                            bound_to = Some(s.value());
+                        } else if inner.path.is_ident("FromHaskell") {
+                            let value = inner.value()?;
+                            let s: LitStr = value.parse()?;
+                            bound_from = Some(s.value());
+                        } else {
+                            return Err(inner.error("expected `ToHaskell` or `FromHaskell`"));
+                        }
+                        Ok(())
+                    })?;
+                }
+                Ok(())
+            });
+        }
+    }
+    HaskellAttrs {
+        name,
+        transparent,
+        style,
+        skip,
+        bound_to,
+        bound_from,
+    }
+}
+
+fn add_trait_bounds(mut generics: syn::Generics, trait_path: &TokenStream2) -> syn::Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(type_param) = param {
+            type_param.bounds.push(syn::parse_quote!(#trait_path));
+        }
+    }
+    generics
+}
+
+fn apply_custom_bounds(
+    generics: &syn::Generics,
+    bound_str: &str,
+) -> syn::Result<(TokenStream2, TokenStream2, TokenStream2)> {
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+    let impl_generics = quote! { #impl_generics };
+    let ty_generics = quote! { #ty_generics };
+    let predicates: TokenStream2 = bound_str.parse().map_err(|e| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("failed to parse bound: {e}"),
+        )
+    })?;
+    let where_clause = quote! { where #predicates };
+    Ok((impl_generics, ty_generics, where_clause))
+}
+
+/// Resolve the effective style for named fields: explicit style wins, otherwise Record.
+fn resolve_style(style: Option<Style>) -> Style {
+    style.unwrap_or(Style::Record)
+}
+
+// ── ToHaskell ────────────────────────────────────────────────────────
+
+/// Derive `ToHaskell` for a struct or enum.
+///
+/// # Container attributes (`#[haskell(...)]`)
+///
+/// - `name = "HaskellName"` — override the Haskell constructor/type name
+/// - `transparent` — single-field struct: delegate to the inner field's impl
+/// - `style = "app"` / `style = "record"` — force app or record syntax for
+///   named-field structs; sets the default for all variants of an enum
+/// - `bound(ToHaskell = "...")` — override auto-generated trait bounds
+///
+/// # Variant attributes (`#[haskell(...)]`)
+///
+/// - `name = "haskell_name"` — override the Haskell constructor name
+/// - `style = "app"` / `style = "record"` — override container default
+///
+/// # Field attributes (`#[haskell(...)]`)
+///
+/// - `name = "haskell_name"` — override the Haskell field name
+/// - `skip` — omit this field from serialization
+#[proc_macro_derive(ToHaskell, attributes(haskell))]
+pub fn derive_to_haskell(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand_to_haskell(input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_to_haskell(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let attrs = parse_haskell_attrs(&input.attrs);
+    let ident = &input.ident;
+    let haskell_name = attrs.name.unwrap_or_else(|| ident.to_string());
+    let container_style = attrs.style;
+
+    let (impl_generics, ty_generics, where_clause) = if let Some(ref bound) = attrs.bound_to {
+        let r = apply_custom_bounds(&input.generics, bound)?;
+        (r.0, r.1, r.2)
+    } else {
+        let trait_path: TokenStream2 = quote!(::ghci::ToHaskell);
+        let generics = add_trait_bounds(input.generics.clone(), &trait_path);
+        let (ig, tg, wc) = generics.split_for_impl();
+        (quote! { #ig }, quote! { #tg }, quote! { #wc })
+    };
+
+    let body = match &input.data {
+        Data::Struct(s) => {
+            if attrs.transparent {
+                expand_to_haskell_transparent_struct(&s.fields)?
+            } else {
+                expand_to_haskell_struct(&s.fields, &haskell_name, container_style)?
+            }
+        }
+        Data::Enum(e) => {
+            if attrs.transparent {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "`#[haskell(transparent)]` is not supported on enums",
+                ));
+            }
+            let arms = e
+                .variants
+                .iter()
+                .map(|v| {
+                    let variant_ident = &v.ident;
+                    let variant_attrs = parse_haskell_attrs(&v.attrs);
+                    let variant_name = variant_attrs
+                        .name
+                        .unwrap_or_else(|| variant_ident.to_string());
+                    let variant_style = variant_attrs.style.or(container_style);
+                    expand_to_haskell_variant(
+                        ident,
+                        variant_ident,
+                        &v.fields,
+                        &variant_name,
+                        variant_style,
+                    )
+                })
+                .collect::<syn::Result<Vec<_>>>()?;
+            quote! {
+                fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                    match self {
+                        #(#arms)*
+                    }
+                }
+            }
+        }
+        Data::Union(u) => {
+            return Err(syn::Error::new_spanned(
+                u.union_token,
+                "`ToHaskell` cannot be derived for unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics ::ghci::ToHaskell for #ident #ty_generics #where_clause {
+            #body
+        }
+    })
+}
+
+fn expand_to_haskell_struct(
+    fields: &Fields,
+    haskell_name: &str,
+    style: Option<Style>,
+) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) => {
+            let effective_style = resolve_style(style);
+            if effective_style == Style::App {
+                let arg_calls = named
+                    .named
+                    .iter()
+                    .filter(|f| !parse_haskell_attrs(&f.attrs).skip)
+                    .map(|f| {
+                        let field_ident = f.ident.as_ref().unwrap();
+                        quote! { .arg(&self.#field_ident) }
+                    });
+                Ok(quote! {
+                    fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                        ::ghci::haskell::app(buf, #haskell_name)
+                            #(#arg_calls)*
+                            .finish()
+                    }
+                })
+            } else {
+                let field_calls = named
+                    .named
+                    .iter()
+                    .filter(|f| !parse_haskell_attrs(&f.attrs).skip)
+                    .map(|f| {
+                        let field_ident = f.ident.as_ref().unwrap();
+                        let fattrs = parse_haskell_attrs(&f.attrs);
+                        let field_name = fattrs.name.unwrap_or_else(|| field_ident.to_string());
+                        quote! { .field(#field_name, &self.#field_ident) }
+                    });
+                Ok(quote! {
+                    fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                        ::ghci::haskell::record(buf, #haskell_name)
+                            #(#field_calls)*
+                            .finish()
+                    }
+                })
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let arg_calls = unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                let index = syn::Index::from(i);
+                quote! { .arg(&self.#index) }
+            });
+            Ok(quote! {
+                fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                    ::ghci::haskell::app(buf, #haskell_name)
+                        #(#arg_calls)*
+                        .finish()
+                }
+            })
+        }
+        Fields::Unit => Ok(quote! {
+            fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                buf.write_str(#haskell_name)
+            }
+        }),
+    }
+}
+
+fn expand_to_haskell_transparent_struct(fields: &Fields) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) if named.named.len() == 1 => {
+            let field_ident = named.named[0].ident.as_ref().unwrap();
+            Ok(quote! {
+                fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                    ::ghci::ToHaskell::write_haskell(&self.#field_ident, buf)
+                }
+            })
+        }
+        Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => Ok(quote! {
+            fn write_haskell(&self, buf: &mut impl ::std::fmt::Write) -> ::std::fmt::Result {
+                ::ghci::ToHaskell::write_haskell(&self.0, buf)
+            }
+        }),
+        _ => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`#[haskell(transparent)]` requires exactly one field",
+        )),
+    }
+}
+
+fn expand_to_haskell_variant(
+    enum_ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    haskell_name: &str,
+    style: Option<Style>,
+) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) => {
+            let effective_style = resolve_style(style);
+            let all_field_idents: Vec<_> = named
+                .named
+                .iter()
+                .map(|f| f.ident.as_ref().unwrap())
+                .collect();
+            if effective_style == Style::App {
+                let non_skipped: Vec<_> = named
+                    .named
+                    .iter()
+                    .filter(|f| !parse_haskell_attrs(&f.attrs).skip)
+                    .map(|f| f.ident.as_ref().unwrap())
+                    .collect();
+                Ok(quote! {
+                    #enum_ident::#variant_ident { #(#all_field_idents),* } => {
+                        ::ghci::haskell::app(buf, #haskell_name)
+                            #(.arg(#non_skipped))*
+                            .finish()
+                    }
+                })
+            } else {
+                let field_stmts: Vec<_> = named
+                    .named
+                    .iter()
+                    .filter(|f| !parse_haskell_attrs(&f.attrs).skip)
+                    .map(|f| {
+                        let fattrs = parse_haskell_attrs(&f.attrs);
+                        let field_ident = f.ident.as_ref().unwrap();
+                        let field_name = fattrs.name.unwrap_or_else(|| field_ident.to_string());
+                        (field_name, field_ident)
+                    })
+                    .collect();
+                let field_names: Vec<_> = field_stmts.iter().map(|(n, _)| n.clone()).collect();
+                let field_idents: Vec<_> = field_stmts.iter().map(|(_, i)| *i).collect();
+                Ok(quote! {
+                    #enum_ident::#variant_ident { #(#all_field_idents),* } => {
+                        ::ghci::haskell::record(buf, #haskell_name)
+                            #(.field(#field_names, #field_idents))*
+                            .finish()
+                    }
+                })
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let vars: Vec<_> = (0..unnamed.unnamed.len())
+                .map(|i| format_ident!("__f{}", i))
+                .collect();
+            Ok(quote! {
+                #enum_ident::#variant_ident(#(#vars),*) => {
+                    ::ghci::haskell::app(buf, #haskell_name)
+                        #(.arg(#vars))*
+                        .finish()
+                }
+            })
+        }
+        Fields::Unit => Ok(quote! {
+            #enum_ident::#variant_ident => buf.write_str(#haskell_name),
+        }),
+    }
+}
+
+// ── FromHaskell ──────────────────────────────────────────────────────
+
+/// Derive `FromHaskell` for a struct or enum.
+///
+/// # Container attributes (`#[haskell(...)]`)
+///
+/// - `name = "HaskellName"` — override the Haskell constructor/type name
+/// - `transparent` — single-field struct: delegate to the inner field's impl
+/// - `style = "app"` / `style = "record"` — force app or record syntax for
+///   named-field structs; sets the default for all variants of an enum
+/// - `bound(FromHaskell = "...")` — override auto-generated trait bounds
+///
+/// # Variant attributes (`#[haskell(...)]`)
+///
+/// - `name = "haskell_name"` — override the Haskell constructor name
+/// - `style = "app"` / `style = "record"` — override container default
+///
+/// # Field attributes (`#[haskell(...)]`)
+///
+/// - `name = "haskell_name"` — override the Haskell field name
+/// - `skip` — initialize with `Default::default()` instead of parsing
+///
+/// For enums, each variant is tried in declaration order; the first successful
+/// parse wins.
+#[proc_macro_derive(FromHaskell, attributes(haskell))]
+pub fn derive_from_haskell(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand_from_haskell(input) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_from_haskell(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let attrs = parse_haskell_attrs(&input.attrs);
+    let ident = &input.ident;
+    let haskell_name = attrs.name.unwrap_or_else(|| ident.to_string());
+    let container_style = attrs.style;
+
+    let (impl_generics, ty_generics, where_clause) = if let Some(ref bound) = attrs.bound_from {
+        let r = apply_custom_bounds(&input.generics, bound)?;
+        (r.0, r.1, r.2)
+    } else {
+        let trait_path: TokenStream2 = quote!(::ghci::FromHaskell);
+        let generics = add_trait_bounds(input.generics.clone(), &trait_path);
+        let (ig, tg, wc) = generics.split_for_impl();
+        (quote! { #ig }, quote! { #tg }, quote! { #wc })
+    };
+
+    let body = match &input.data {
+        Data::Struct(s) => {
+            if attrs.transparent {
+                expand_from_haskell_transparent_struct(&s.fields)?
+            } else {
+                expand_from_haskell_struct(&s.fields, &haskell_name, container_style)?
+            }
+        }
+        Data::Enum(e) => {
+            if attrs.transparent {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "`#[haskell(transparent)]` is not supported on enums",
+                ));
+            }
+            let type_name = ident.to_string();
+            let tries = e
+                .variants
+                .iter()
+                .map(|v| {
+                    let variant_ident = &v.ident;
+                    let variant_attrs = parse_haskell_attrs(&v.attrs);
+                    let variant_name = variant_attrs
+                        .name
+                        .unwrap_or_else(|| variant_ident.to_string());
+                    let variant_style = variant_attrs.style.or(container_style);
+                    expand_from_haskell_variant(
+                        ident,
+                        variant_ident,
+                        &v.fields,
+                        &variant_name,
+                        variant_style,
+                    )
+                })
+                .collect::<syn::Result<Vec<_>>>()?;
+            quote! {
+                fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                    #(#tries)*
+                    ::core::result::Result::Err(::ghci::HaskellParseError::ParseError {
+                        message: ::std::format!("failed to parse {} from {:?}", #type_name, input),
+                    })
+                }
+            }
+        }
+        Data::Union(u) => {
+            return Err(syn::Error::new_spanned(
+                u.union_token,
+                "`FromHaskell` cannot be derived for unions",
+            ));
+        }
+    };
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #impl_generics ::ghci::FromHaskell for #ident #ty_generics #where_clause {
+            #body
+        }
+    })
+}
+
+fn expand_from_haskell_struct(
+    fields: &Fields,
+    haskell_name: &str,
+    style: Option<Style>,
+) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) => {
+            let effective_style = resolve_style(style);
+            if effective_style == Style::App {
+                let field_inits: Vec<_> = named
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let field_ident = f.ident.as_ref().unwrap();
+                        let fattrs = parse_haskell_attrs(&f.attrs);
+                        if fattrs.skip {
+                            quote! { #field_ident: ::core::default::Default::default() }
+                        } else {
+                            quote! { #field_ident: __p.arg()? }
+                        }
+                    })
+                    .collect();
+                Ok(quote! {
+                    fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                        let mut __p = ::ghci::haskell::parse_app(#haskell_name, input)?;
+                        let __val = Self { #(#field_inits),* };
+                        let rest = __p.finish()?;
+                        ::core::result::Result::Ok((__val, rest))
+                    }
+                })
+            } else {
+                let field_inits = named.named.iter().map(|f| {
+                    let field_ident = f.ident.as_ref().unwrap();
+                    let fattrs = parse_haskell_attrs(&f.attrs);
+                    if fattrs.skip {
+                        quote! { #field_ident: ::core::default::Default::default() }
+                    } else {
+                        let field_name = fattrs.name.unwrap_or_else(|| field_ident.to_string());
+                        quote! { #field_ident: rec.field(#field_name)? }
+                    }
+                });
+                Ok(quote! {
+                    fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                        let (rec, rest) = ::ghci::haskell::parse_record(#haskell_name, input)?;
+                        ::core::result::Result::Ok((Self { #(#field_inits),* }, rest))
+                    }
+                })
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let vars: Vec<_> = (0..unnamed.unnamed.len())
+                .map(|i| format_ident!("__f{}", i))
+                .collect();
+            Ok(quote! {
+                fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                    let mut __p = ::ghci::haskell::parse_app(#haskell_name, input)?;
+                    #(let #vars = __p.arg()?;)*
+                    let rest = __p.finish()?;
+                    ::core::result::Result::Ok((Self(#(#vars),*), rest))
+                }
+            })
+        }
+        Fields::Unit => Ok(quote! {
+            fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                let mut __p = ::ghci::haskell::parse_app(#haskell_name, input)?;
+                let rest = __p.finish()?;
+                ::core::result::Result::Ok((Self, rest))
+            }
+        }),
+    }
+}
+
+fn expand_from_haskell_transparent_struct(fields: &Fields) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) if named.named.len() == 1 => {
+            let field_ident = named.named[0].ident.as_ref().unwrap();
+            Ok(quote! {
+                fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                    let (val, rest) = ::ghci::FromHaskell::parse_haskell(input)?;
+                    ::core::result::Result::Ok((Self { #field_ident: val }, rest))
+                }
+            })
+        }
+        Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => Ok(quote! {
+            fn parse_haskell(input: &str) -> ::core::result::Result<(Self, &str), ::ghci::HaskellParseError> {
+                let (val, rest) = ::ghci::FromHaskell::parse_haskell(input)?;
+                ::core::result::Result::Ok((Self(val), rest))
+            }
+        }),
+        _ => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`#[haskell(transparent)]` requires exactly one field",
+        )),
+    }
+}
+
+fn expand_from_haskell_variant(
+    enum_ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    haskell_name: &str,
+    style: Option<Style>,
+) -> syn::Result<TokenStream2> {
+    match fields {
+        Fields::Named(named) => {
+            let effective_style = resolve_style(style);
+            if effective_style == Style::App {
+                let field_inits: Vec<_> = named
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let field_ident = f.ident.as_ref().unwrap();
+                        let fattrs = parse_haskell_attrs(&f.attrs);
+                        if fattrs.skip {
+                            quote! { #field_ident: ::core::default::Default::default() }
+                        } else {
+                            quote! { #field_ident: __p.arg()? }
+                        }
+                    })
+                    .collect();
+                Ok(quote! {
+                    if let ::core::result::Result::Ok(mut __p) = ::ghci::haskell::parse_app(#haskell_name, input) {
+                        let __val = #enum_ident::#variant_ident { #(#field_inits),* };
+                        let rest = __p.finish()?;
+                        return ::core::result::Result::Ok((__val, rest));
+                    }
+                })
+            } else {
+                let field_inits: Vec<_> = named
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let field_ident = f.ident.as_ref().unwrap();
+                        let fattrs = parse_haskell_attrs(&f.attrs);
+                        if fattrs.skip {
+                            quote! { #field_ident: ::core::default::Default::default() }
+                        } else {
+                            let field_name = fattrs
+                                .name
+                                .unwrap_or_else(|| f.ident.as_ref().unwrap().to_string());
+                            quote! { #field_ident: rec.field(#field_name)? }
+                        }
+                    })
+                    .collect();
+                Ok(quote! {
+                    if let ::core::result::Result::Ok((rec, rest)) = ::ghci::haskell::parse_record(#haskell_name, input) {
+                        return ::core::result::Result::Ok((
+                            #enum_ident::#variant_ident { #(#field_inits),* },
+                            rest,
+                        ));
+                    }
+                })
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let vars: Vec<_> = (0..unnamed.unnamed.len())
+                .map(|i| format_ident!("__f{}", i))
+                .collect();
+            Ok(quote! {
+                if let ::core::result::Result::Ok(mut __p) = ::ghci::haskell::parse_app(#haskell_name, input) {
+                    #(let #vars = __p.arg()?;)*
+                    let rest = __p.finish()?;
+                    return ::core::result::Result::Ok((#enum_ident::#variant_ident(#(#vars),*), rest));
+                }
+            })
+        }
+        Fields::Unit => Ok(quote! {
+            if let ::core::result::Result::Ok(mut __p) = ::ghci::haskell::parse_app(#haskell_name, input) {
+                let rest = __p.finish()?;
+                return ::core::result::Result::Ok((#enum_ident::#variant_ident, rest));
+            }
+        }),
+    }
+}

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -649,6 +649,23 @@ fn parse_constructor(input: &str) -> Result<(&str, &str), HaskellParseError> {
     Ok((&input[..end], &input[end..]))
 }
 
+fn parse_identifier(input: &str) -> Result<(&str, &str), HaskellParseError> {
+    let input = skip_ws(input);
+    let first = input
+        .chars()
+        .next()
+        .ok_or(HaskellParseError::UnexpectedEnd)?;
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return Err(HaskellParseError::ParseError {
+            message: format!("expected identifier, got {input:?}"),
+        });
+    }
+    let end = input
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '\'')
+        .unwrap_or(input.len());
+    Ok((&input[..end], &input[end..]))
+}
+
 #[allow(clippy::type_complexity)]
 fn parse_record_fields(input: &str) -> Result<(Vec<(&str, &str)>, &str), HaskellParseError> {
     let input = skip_ws(input);
@@ -994,7 +1011,7 @@ pub fn parse_app<'a>(
     // Try parenthesized: (Constructor ...)
     if let Some(inner) = input.strip_prefix('(') {
         let inner = skip_ws(inner);
-        let (name, rest) = parse_constructor(inner)?;
+        let (name, rest) = parse_identifier(inner)?;
         if name != constructor {
             return Err(HaskellParseError::ParseError {
                 message: format!("expected constructor {constructor:?}, got {name:?}"),
@@ -1006,7 +1023,7 @@ pub fn parse_app<'a>(
         });
     }
     // Bare constructor
-    let (name, rest) = parse_constructor(input)?;
+    let (name, rest) = parse_identifier(input)?;
     if name != constructor {
         return Err(HaskellParseError::ParseError {
             message: format!("expected constructor {constructor:?}, got {name:?}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ use std::time::Instant;
 pub mod haskell;
 pub use haskell::{FromHaskell, HaskellParseError, ToHaskell};
 
+#[cfg(feature = "derive")]
+pub use ghci_derive::{FromHaskell, ToHaskell};
+
 /// A ghci session handle
 ///
 /// The session is stateful, so the order of interaction matters

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,0 +1,506 @@
+use ghci::{FromHaskell, ToHaskell};
+
+// ── Named struct ─────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+#[test]
+fn named_struct_to_haskell() {
+    let p = Point { x: 1, y: 2 };
+    assert_eq!(p.to_haskell(), "Point {x = 1, y = 2}");
+}
+
+#[test]
+fn named_struct_from_haskell() {
+    let p = Point::from_haskell("Point {x = 1, y = 2}").unwrap();
+    assert_eq!(p, Point { x: 1, y: 2 });
+}
+
+#[test]
+fn named_struct_roundtrip() {
+    let p = Point { x: 42, y: 99 };
+    assert_eq!(Point::from_haskell(&p.to_haskell()).unwrap(), p);
+}
+
+// ── Tuple struct ─────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+struct Pair(u32, bool);
+
+#[test]
+fn tuple_struct_to_haskell() {
+    assert_eq!(Pair(1, true).to_haskell(), "(Pair 1 True)");
+}
+
+#[test]
+fn tuple_struct_from_haskell() {
+    assert_eq!(Pair::from_haskell("(Pair 1 True)").unwrap(), Pair(1, true));
+}
+
+#[test]
+fn tuple_struct_roundtrip() {
+    let p = Pair(7, false);
+    assert_eq!(Pair::from_haskell(&p.to_haskell()).unwrap(), p);
+}
+
+// ── Unit struct ──────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+struct Unit;
+
+#[test]
+fn unit_struct_to_haskell() {
+    assert_eq!(Unit.to_haskell(), "Unit");
+}
+
+#[test]
+fn unit_struct_from_haskell() {
+    assert_eq!(Unit::from_haskell("Unit").unwrap(), Unit);
+}
+
+// ── Transparent newtype ──────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(transparent)]
+struct Meters(f64);
+
+#[test]
+fn transparent_to_haskell() {
+    assert_eq!(Meters(3.14).to_haskell(), 3.14f64.to_haskell());
+}
+
+#[test]
+fn transparent_from_haskell() {
+    let m = Meters::from_haskell("3.14").unwrap();
+    assert_eq!(m, Meters(3.14));
+}
+
+// ── Custom Haskell names ─────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(name = "Vec2")]
+struct Vec2 {
+    #[haskell(name = "vecX")]
+    x: f64,
+    #[haskell(name = "vecY")]
+    y: f64,
+}
+
+#[test]
+fn custom_name_to_haskell() {
+    let v = Vec2 { x: 1.0, y: 2.0 };
+    assert_eq!(v.to_haskell(), "Vec2 {vecX = 1.0, vecY = 2.0}");
+}
+
+#[test]
+fn custom_name_from_haskell() {
+    let v = Vec2::from_haskell("Vec2 {vecX = 1.0, vecY = 2.0}").unwrap();
+    assert_eq!(v, Vec2 { x: 1.0, y: 2.0 });
+}
+
+// ── Enum ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+enum Shape {
+    Circle { radius: f64 },
+    Rect(f64, f64),
+    Empty,
+}
+
+#[test]
+fn enum_named_variant_to_haskell() {
+    assert_eq!(
+        Shape::Circle { radius: 2.5 }.to_haskell(),
+        "Circle {radius = 2.5}"
+    );
+}
+
+#[test]
+fn enum_named_variant_from_haskell() {
+    assert_eq!(
+        Shape::from_haskell("Circle {radius = 2.5}").unwrap(),
+        Shape::Circle { radius: 2.5 }
+    );
+}
+
+#[test]
+fn enum_tuple_variant_to_haskell() {
+    assert_eq!(Shape::Rect(3.0, 4.0).to_haskell(), "(Rect 3.0 4.0)");
+}
+
+#[test]
+fn enum_tuple_variant_from_haskell() {
+    assert_eq!(
+        Shape::from_haskell("(Rect 3.0 4.0)").unwrap(),
+        Shape::Rect(3.0, 4.0)
+    );
+}
+
+#[test]
+fn enum_unit_variant_to_haskell() {
+    assert_eq!(Shape::Empty.to_haskell(), "Empty");
+}
+
+#[test]
+fn enum_unit_variant_from_haskell() {
+    assert_eq!(Shape::from_haskell("Empty").unwrap(), Shape::Empty);
+}
+
+#[test]
+fn enum_roundtrips() {
+    for shape in [
+        Shape::Circle { radius: 1.0 },
+        Shape::Rect(2.0, 3.0),
+        Shape::Empty,
+    ] {
+        let s = shape.to_haskell();
+        assert_eq!(Shape::from_haskell(&s).unwrap(), shape);
+    }
+}
+
+// ── Generic struct ───────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+struct Wrapper<T> {
+    value: T,
+}
+
+#[test]
+fn generic_struct_roundtrip() {
+    let w = Wrapper { value: 42u32 };
+    assert_eq!(Wrapper::<u32>::from_haskell(&w.to_haskell()).unwrap(), w);
+}
+
+// ── Enum with custom variant names ───────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+enum Color {
+    #[haskell(name = "Red")]
+    Red,
+    #[haskell(name = "Green")]
+    Green,
+    #[haskell(name = "Blue")]
+    Blue,
+}
+
+#[test]
+fn enum_custom_variant_names() {
+    assert_eq!(Color::Red.to_haskell(), "Red");
+    assert_eq!(Color::from_haskell("Green").unwrap(), Color::Green);
+}
+
+// ── style = "app" on named struct ───────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(style = "app")]
+struct Tagged {
+    label: usize,
+    active: bool,
+}
+
+#[test]
+fn app_style_named_struct_to_haskell() {
+    let t = Tagged {
+        label: 42,
+        active: true,
+    };
+    assert_eq!(t.to_haskell(), "(Tagged 42 True)");
+}
+
+#[test]
+fn app_style_named_struct_from_haskell() {
+    assert_eq!(
+        Tagged::from_haskell("(Tagged 42 True)").unwrap(),
+        Tagged {
+            label: 42,
+            active: true
+        }
+    );
+}
+
+#[test]
+fn app_style_named_struct_roundtrip() {
+    let t = Tagged {
+        label: 7,
+        active: false,
+    };
+    assert_eq!(Tagged::from_haskell(&t.to_haskell()).unwrap(), t);
+}
+
+// ── style = "app" on enum variants (with lowercase renamed constructors) ─
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+enum Strategy {
+    #[haskell(name = "greedyStrategy", style = "app")]
+    Greedy { limit: usize },
+    #[haskell(name = "lazyStrategy", style = "app")]
+    Lazy { threshold: usize },
+}
+
+#[test]
+fn app_style_enum_variant_to_haskell() {
+    assert_eq!(
+        Strategy::Greedy { limit: 4 }.to_haskell(),
+        "(greedyStrategy 4)"
+    );
+    assert_eq!(
+        Strategy::Lazy { threshold: 10 }.to_haskell(),
+        "(lazyStrategy 10)"
+    );
+}
+
+#[test]
+fn app_style_enum_variant_from_haskell() {
+    assert_eq!(
+        Strategy::from_haskell("(greedyStrategy 4)").unwrap(),
+        Strategy::Greedy { limit: 4 }
+    );
+    assert_eq!(
+        Strategy::from_haskell("(lazyStrategy 10)").unwrap(),
+        Strategy::Lazy { threshold: 10 }
+    );
+}
+
+#[test]
+fn app_style_enum_variant_roundtrip() {
+    for s in [
+        Strategy::Greedy { limit: 0 },
+        Strategy::Lazy { threshold: 99 },
+    ] {
+        assert_eq!(Strategy::from_haskell(&s.to_haskell()).unwrap(), s);
+    }
+}
+
+// ── Container-level style = "app" on enum ───────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(style = "app")]
+enum Move {
+    Forward { steps: u32 },
+    Backward { steps: u32 },
+}
+
+#[test]
+fn container_app_style_enum() {
+    assert_eq!(Move::Forward { steps: 5 }.to_haskell(), "(Forward 5)");
+    assert_eq!(
+        Move::from_haskell("(Backward 3)").unwrap(),
+        Move::Backward { steps: 3 }
+    );
+}
+
+// ── skip in app style ───────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(style = "app")]
+struct Config {
+    enabled: bool,
+    level: usize,
+    verbose: bool,
+    #[haskell(skip)]
+    cached: usize,
+}
+
+#[test]
+fn skip_field_app_to_haskell() {
+    let c = Config {
+        enabled: true,
+        level: 3,
+        verbose: false,
+        cached: 999,
+    };
+    assert_eq!(c.to_haskell(), "(Config True 3 False)");
+}
+
+#[test]
+fn skip_field_app_from_haskell() {
+    let c = Config::from_haskell("(Config True 3 False)").unwrap();
+    assert!(c.enabled);
+    assert_eq!(c.level, 3);
+    assert!(!c.verbose);
+    assert_eq!(c.cached, 0); // Default::default()
+}
+
+// ── skip in app style roundtrip ──────────────────────────────────────
+
+#[test]
+fn skip_field_app_roundtrip() {
+    let c = Config {
+        enabled: false,
+        level: 5,
+        verbose: true,
+        cached: 123,
+    };
+    let parsed = Config::from_haskell(&c.to_haskell()).unwrap();
+    assert_eq!(parsed.enabled, c.enabled);
+    assert_eq!(parsed.level, c.level);
+    assert_eq!(parsed.verbose, c.verbose);
+    assert_eq!(parsed.cached, 0); // skipped, so default
+}
+
+// ── skip in record style ────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+struct Settings {
+    visible: u32,
+    #[haskell(skip)]
+    internal: u32,
+}
+
+#[test]
+fn skip_field_record_to_haskell() {
+    let s = Settings {
+        visible: 42,
+        internal: 999,
+    };
+    assert_eq!(s.to_haskell(), "Settings {visible = 42}");
+}
+
+#[test]
+fn skip_field_record_from_haskell() {
+    let s = Settings::from_haskell("Settings {visible = 42}").unwrap();
+    assert_eq!(s.visible, 42);
+    assert_eq!(s.internal, 0);
+}
+
+#[test]
+fn skip_field_record_roundtrip() {
+    let s = Settings {
+        visible: 7,
+        internal: 888,
+    };
+    let parsed = Settings::from_haskell(&s.to_haskell()).unwrap();
+    assert_eq!(parsed.visible, 7);
+    assert_eq!(parsed.internal, 0);
+}
+
+// ── skip on enum variant fields ─────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+enum Action {
+    #[haskell(style = "app")]
+    Run {
+        speed: u32,
+        #[haskell(skip)]
+        debug_id: u32,
+    },
+    Idle,
+}
+
+#[test]
+fn skip_field_enum_variant_to_haskell() {
+    assert_eq!(
+        Action::Run {
+            speed: 10,
+            debug_id: 999
+        }
+        .to_haskell(),
+        "(Run 10)"
+    );
+}
+
+#[test]
+fn skip_field_enum_variant_from_haskell() {
+    let a = Action::from_haskell("(Run 10)").unwrap();
+    assert_eq!(
+        a,
+        Action::Run {
+            speed: 10,
+            debug_id: 0
+        }
+    );
+}
+
+#[test]
+fn skip_field_enum_variant_roundtrip() {
+    let a = Action::Run {
+        speed: 5,
+        debug_id: 42,
+    };
+    let parsed = Action::from_haskell(&a.to_haskell()).unwrap();
+    assert_eq!(
+        parsed,
+        Action::Run {
+            speed: 5,
+            debug_id: 0
+        }
+    );
+}
+
+// ── explicit style = "record" ───────────────────────────────────────
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(style = "record")]
+struct Explicit {
+    x: u32,
+    y: u32,
+}
+
+#[test]
+fn explicit_record_style() {
+    let e = Explicit { x: 1, y: 2 };
+    assert_eq!(e.to_haskell(), "Explicit {x = 1, y = 2}");
+    assert_eq!(Explicit::from_haskell(&e.to_haskell()).unwrap(), e);
+}
+
+// ── bound ───────────────────────────────────────────────────────────
+
+// A type that only implements ToHaskell/FromHaskell for a specific monomorphization.
+#[derive(Debug, PartialEq)]
+struct Tagged2<T> {
+    inner: T,
+}
+
+impl ToHaskell for Tagged2<usize> {
+    fn write_haskell(&self, buf: &mut impl std::fmt::Write) -> std::fmt::Result {
+        ghci::haskell::app(buf, "Tagged2").arg(&self.inner).finish()
+    }
+}
+
+impl FromHaskell for Tagged2<usize> {
+    fn parse_haskell(input: &str) -> Result<(Self, &str), ghci::HaskellParseError> {
+        let mut p = ghci::haskell::parse_app("Tagged2", input)?;
+        let inner = p.arg()?;
+        let rest = p.finish()?;
+        Ok((Tagged2 { inner }, rest))
+    }
+}
+
+#[derive(Debug, PartialEq, ToHaskell, FromHaskell)]
+#[haskell(bound(
+    ToHaskell = "A: ::ghci::ToHaskell, Tagged2<A>: ::ghci::ToHaskell",
+    FromHaskell = "A: ::ghci::FromHaskell, Tagged2<A>: ::ghci::FromHaskell",
+))]
+struct Bundle<A> {
+    plain: A,
+    tagged: Tagged2<A>,
+}
+
+#[test]
+fn custom_bound_to_haskell() {
+    let b = Bundle {
+        plain: 5usize,
+        tagged: Tagged2 { inner: 10 },
+    };
+    assert_eq!(b.to_haskell(), "Bundle {plain = 5, tagged = (Tagged2 10)}");
+}
+
+#[test]
+fn custom_bound_from_haskell() {
+    let b = Bundle::<usize>::from_haskell("Bundle {plain = 5, tagged = (Tagged2 10)}").unwrap();
+    assert_eq!(b.plain, 5);
+    assert_eq!(b.tagged, Tagged2 { inner: 10 });
+}
+
+#[test]
+fn custom_bound_roundtrip() {
+    let b = Bundle {
+        plain: 42usize,
+        tagged: Tagged2 { inner: 99 },
+    };
+    assert_eq!(Bundle::<usize>::from_haskell(&b.to_haskell()).unwrap(), b);
+}


### PR DESCRIPTION
## Summary

- Adds a new `ghci-derive` proc-macro crate, gated behind a `derive` feature flag on the main crate
- Derives `ToHaskell` and `FromHaskell` for structs and enums with the following attributes:
  - `#[haskell(name = "...")]` — override constructor/field/variant names
  - `#[haskell(transparent)]` — delegate to the single inner field
  - `#[haskell(style = "app"|"record")]` — control named-field serialization style (container or variant level); enables named-field structs to serialize as `(Con a b c)` instead of `Con {x = a}`
  - `#[haskell(skip)]` — omit a field from serialization, populate with `Default::default()` on parse
  - `#[haskell(bound(ToHaskell = "...", FromHaskell = "..."))]` — override auto-generated trait bounds for generic types
- Extends `parse_app` in `haskell.rs` to accept lowercase-starting identifiers, supporting renamed constructors

🤖 Generated with [Claude Code](https://claude.com/claude-code)