### PR TITLE
Fix all clippy warnings and errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1176,8 +1176,14 @@ mod tests {
         assert!((f64::from_haskell("3.0").unwrap() - 3.0).abs() < f64::EPSILON);
         assert!((f64::from_haskell("(-3.0)").unwrap() + 3.0).abs() < f64::EPSILON);
         assert!(f64::from_haskell("(0/0)").unwrap().is_nan());
-        assert!(f64::from_haskell("(1/0)").unwrap().is_infinite() && f64::from_haskell("(1/0)").unwrap().is_sign_positive());
-        assert!(f64::from_haskell("((-1)/0)").unwrap().is_infinite() && f64::from_haskell("((-1)/0)").unwrap().is_sign_negative());
+        assert!(
+            f64::from_haskell("(1/0)").unwrap().is_infinite()
+                && f64::from_haskell("(1/0)").unwrap().is_sign_positive()
+        );
+        assert!(
+            f64::from_haskell("((-1)/0)").unwrap().is_infinite()
+                && f64::from_haskell("((-1)/0)").unwrap().is_sign_negative()
+        );
     }
 
     #[test]

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1147,15 +1147,15 @@ mod tests {
     #[test]
     fn ref_to_haskell() {
         let x = 42u32;
-        assert_eq!((&x).to_haskell(), "42");
+        assert_eq!(x.to_haskell(), "42");
     }
 
     // ── FromHaskell tests ────────────────────────────────────────────
 
     #[test]
     fn bool_from_haskell() {
-        assert_eq!(bool::from_haskell("True").unwrap(), true);
-        assert_eq!(bool::from_haskell("False").unwrap(), false);
+        assert!(bool::from_haskell("True").unwrap());
+        assert!(!bool::from_haskell("False").unwrap());
     }
 
     #[test]
@@ -1176,8 +1176,8 @@ mod tests {
         assert!((f64::from_haskell("3.0").unwrap() - 3.0).abs() < f64::EPSILON);
         assert!((f64::from_haskell("(-3.0)").unwrap() + 3.0).abs() < f64::EPSILON);
         assert!(f64::from_haskell("(0/0)").unwrap().is_nan());
-        assert_eq!(f64::from_haskell("(1/0)").unwrap(), f64::INFINITY);
-        assert_eq!(f64::from_haskell("((-1)/0)").unwrap(), f64::NEG_INFINITY);
+        assert!(f64::from_haskell("(1/0)").unwrap().is_infinite() && f64::from_haskell("(1/0)").unwrap().is_sign_positive());
+        assert!(f64::from_haskell("((-1)/0)").unwrap().is_infinite() && f64::from_haskell("((-1)/0)").unwrap().is_sign_negative());
     }
 
     #[test]
@@ -1330,7 +1330,7 @@ mod tests {
     fn parse_record_basic() {
         let (rec, rest) = parse_record("Foo", "Foo {bar = 42, baz = True}").unwrap();
         assert_eq!(rec.field::<u32>("bar").unwrap(), 42);
-        assert_eq!(rec.field::<bool>("baz").unwrap(), true);
+        assert!(rec.field::<bool>("baz").unwrap());
         assert_eq!(rest, "");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,7 @@ mod tests {
     fn eval_as_boolean() -> Result<()> {
         let mut ghci = Ghci::new()?;
         let b: bool = ghci.eval_as("True")?;
-        assert_eq!(b, true);
+        assert!(b);
         Ok(())
     }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -70,13 +70,13 @@ struct Meters(f64);
 
 #[test]
 fn transparent_to_haskell() {
-    assert_eq!(Meters(3.14).to_haskell(), 3.14f64.to_haskell());
+    assert_eq!(Meters(1.23).to_haskell(), 1.23f64.to_haskell());
 }
 
 #[test]
 fn transparent_from_haskell() {
-    let m = Meters::from_haskell("3.14").unwrap();
-    assert_eq!(m, Meters(3.14));
+    let m = Meters::from_haskell("1.23").unwrap();
+    assert_eq!(m, Meters(1.23));
 }
 
 // ── Custom Haskell names ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Tighten CI: clippy now runs with `--all-features --all-targets -D warnings`
- Fix resulting warnings/errors: needless borrows, `assert_eq!` with bool literals, strict float comparisons, and approximate-PI constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)