### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.1] - 2026/03/15
+
+### Added
+
+- `ghci-derive` crate with derive macros for `ToHaskell` and `FromHaskell` traits (enable via the `derive` feature).
+
 ## [0.2.0] - 2026/03/14
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "ghci-derive"]
 
 [package]
 name = "ghci"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/basile-henry/ghci-rs"
 authors = ["Basile Henry <bjm.henry@gmail.com>"]
 license = "MIT"
@@ -19,7 +19,7 @@ derive = ["dep:ghci-derive"]
 nix = { version = "0.29", features = ["poll"], default-features = false }
 nonblock = "0.2"
 thiserror = "2"
-ghci-derive = { version = "0.2.0", path = "ghci-derive", optional = true }
+ghci-derive = { version = "0.2.1", path = "ghci-derive", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/ghci-derive/Cargo.toml
+++ b/ghci-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghci-derive"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/basile-henry/ghci-rs"
 authors = ["Basile Henry <bjm.henry@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, clippy::cargo)]
-#![doc(html_root_url = "https://docs.rs/ghci/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/ghci/0.2.1")]
 
 //! A crate to manage and communicate with `ghci` sessions
 //!


### PR DESCRIPTION
## Summary

- Bump `ghci` and `ghci-derive` to `0.2.1`
- Add CHANGELOG entry for `0.2.1` (derive macros via the `derive` feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)