### PR TITLE
Fix bugs, expand docs, add try_lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [0.2.1] - 2026/03/15
 
+### Fixed
+
+- Float `ToHaskell` no longer truncates to 1 decimal place — full precision is preserved.
+- `Drop` impl no longer panics if the child process is in an unexpected state.
+- `clear_blocking_reader_until` no longer panics when ghci startup output exceeds 1024 bytes.
+- `FromHaskell` now handles all Haskell escape sequences (`\a`, `\b`, `\f`, `\v`, and named escapes like `\NUL`, `\SOH`, `\DEL`, etc.).
+
 ### Added
 
 - `ghci-derive` crate with derive macros for `ToHaskell` and `FromHaskell` traits (enable via the `derive` feature).
+- `SharedGhci::try_lock()` — fallible alternative to `lock()` that returns `Result` instead of panicking on mutex poisoning.
 
 ## [0.2.0] - 2026/03/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Float `ToHaskell` no longer truncates to 1 decimal place — full precision is preserved.
 - `Drop` impl no longer panics if the child process is in an unexpected state.
 - `clear_blocking_reader_until` no longer panics when ghci startup output exceeds 1024 bytes.
-- `FromHaskell` now handles all Haskell escape sequences (`\a`, `\b`, `\f`, `\v`, and named escapes like `\NUL`, `\SOH`, `\DEL`, etc.).
+- `FromHaskell` now handles all Haskell escape sequences (`\a`, `\b`, `\f`, `\v`, named escapes like `\NUL`, `\SOH`, `\DEL`, and the `\&` empty escape for disambiguation).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,88 @@ let out = ghci.eval("putStrLn \"Hello world\"")?;
 assert_eq!(out, "Hello world\n");
 ```
 
-See the [docs](https://docs.rs/ghci) for more.
-
 > **Platform support:** Unix only (Linux, macOS, BSDs).
+
+## Features
+
+### Type conversions
+
+Convert between Rust and Haskell values with `ToHaskell` / `FromHaskell`, and evaluate expressions directly into Rust types with `eval_as`:
+
+```rust
+use ghci::{Ghci, ToHaskell, FromHaskell};
+
+let mut ghci = Ghci::new()?;
+
+let x: i32 = ghci.eval_as("1 + 1")?;
+assert_eq!(x, 2);
+
+// Built-in support for common types
+assert_eq!(true.to_haskell(), "True");
+assert_eq!(Some(42u32).to_haskell(), "(Just 42)");
+assert_eq!(vec![1u32, 2, 3].to_haskell(), "[1, 2, 3]");
+```
+
+### Derive macros
+
+With the `derive` feature, automatically derive conversions for your own types:
+
+```rust
+use ghci::{ToHaskell, FromHaskell};
+
+#[derive(ToHaskell, FromHaskell)]
+struct Point { x: u32, y: u32 }
+// Point { x: 1, y: 2 } <-> "Point {x = 1, y = 2}"
+
+#[derive(ToHaskell, FromHaskell)]
+#[haskell(style = "app")]
+struct Pair(u32, bool);
+// Pair(1, true) <-> "(Pair 1 True)"
+```
+
+See the [derive macro docs](https://docs.rs/ghci-derive) for all supported attributes (`name`, `transparent`, `style`, `skip`, `bound`).
+
+### Configuration
+
+Use `GhciBuilder` to configure the ghci session:
+
+```rust
+use ghci::GhciBuilder;
+
+let mut ghci = GhciBuilder::new()
+    .ghci_path("/usr/local/bin/ghci")
+    .arg("-XOverloadedStrings")
+    .working_dir("/path/to/project")
+    .build()?;
+```
+
+### Timeouts
+
+```rust
+use std::time::Duration;
+
+ghci.set_timeout(Some(Duration::from_secs(5)));
+```
+
+### Shared sessions
+
+`SharedGhci` provides a thread-safe, lazily-initialized session for use in tests:
+
+```rust
+use ghci::{Ghci, SharedGhci};
+
+static GHCI: SharedGhci = SharedGhci::new(|| {
+    let mut ghci = Ghci::new()?;
+    ghci.import(&["Data.Char"])?;
+    Ok(ghci)
+});
+
+let mut ghci = GHCI.lock();
+let out = ghci.eval("ord 'A'").unwrap();
+assert_eq!(out, "65\n");
+```
+
+See the [docs](https://docs.rs/ghci) for the full API.
 
 ## License
 

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -179,7 +179,17 @@ impl_to_haskell_float!(f32, f64);
 impl ToHaskell for str {
     fn write_haskell(&self, buf: &mut impl fmt::Write) -> fmt::Result {
         buf.write_char('"')?;
+        let mut prev_was_numeric_escape = false;
         for c in self.chars() {
+            // After a numeric escape like \0 or \31, a following digit would
+            // be consumed as part of the escape. Insert \& to disambiguate.
+            if prev_was_numeric_escape && c.is_ascii_digit() {
+                buf.write_str("\\&")?;
+            }
+            // \0 and other control chars (except \n, \t, \r which use named
+            // escapes) produce numeric escapes
+            prev_was_numeric_escape =
+                c == '\0' || (c.is_ascii_control() && !matches!(c, '\n' | '\t' | '\r'));
             write_haskell_char_escaped(buf, c, '"')?;
         }
         buf.write_char('"')

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1276,6 +1276,59 @@ mod tests {
     }
 
     #[test]
+    fn single_char_escapes_from_haskell() {
+        assert_eq!(char::from_haskell("'\\a'").unwrap(), '\x07');
+        assert_eq!(char::from_haskell("'\\b'").unwrap(), '\x08');
+        assert_eq!(char::from_haskell("'\\f'").unwrap(), '\x0C');
+        assert_eq!(char::from_haskell("'\\v'").unwrap(), '\x0B');
+    }
+
+    #[test]
+    fn named_escapes_from_haskell() {
+        assert_eq!(String::from_haskell(r#""\NUL""#).unwrap(), "\x00");
+        assert_eq!(String::from_haskell(r#""\SOH""#).unwrap(), "\x01");
+        assert_eq!(String::from_haskell(r#""\STX""#).unwrap(), "\x02");
+        assert_eq!(String::from_haskell(r#""\ETX""#).unwrap(), "\x03");
+        assert_eq!(String::from_haskell(r#""\EOT""#).unwrap(), "\x04");
+        assert_eq!(String::from_haskell(r#""\ENQ""#).unwrap(), "\x05");
+        assert_eq!(String::from_haskell(r#""\ACK""#).unwrap(), "\x06");
+        assert_eq!(String::from_haskell(r#""\BEL""#).unwrap(), "\x07");
+        assert_eq!(String::from_haskell(r#""\BS""#).unwrap(), "\x08");
+        assert_eq!(String::from_haskell(r#""\HT""#).unwrap(), "\x09");
+        assert_eq!(String::from_haskell(r#""\LF""#).unwrap(), "\x0A");
+        assert_eq!(String::from_haskell(r#""\VT""#).unwrap(), "\x0B");
+        assert_eq!(String::from_haskell(r#""\FF""#).unwrap(), "\x0C");
+        assert_eq!(String::from_haskell(r#""\CR""#).unwrap(), "\x0D");
+        assert_eq!(String::from_haskell(r#""\SO""#).unwrap(), "\x0E");
+        assert_eq!(String::from_haskell(r#""\SI""#).unwrap(), "\x0F");
+        assert_eq!(String::from_haskell(r#""\DLE""#).unwrap(), "\x10");
+        assert_eq!(String::from_haskell(r#""\DC1""#).unwrap(), "\x11");
+        assert_eq!(String::from_haskell(r#""\DC2""#).unwrap(), "\x12");
+        assert_eq!(String::from_haskell(r#""\DC3""#).unwrap(), "\x13");
+        assert_eq!(String::from_haskell(r#""\DC4""#).unwrap(), "\x14");
+        assert_eq!(String::from_haskell(r#""\NAK""#).unwrap(), "\x15");
+        assert_eq!(String::from_haskell(r#""\SYN""#).unwrap(), "\x16");
+        assert_eq!(String::from_haskell(r#""\ETB""#).unwrap(), "\x17");
+        assert_eq!(String::from_haskell(r#""\CAN""#).unwrap(), "\x18");
+        assert_eq!(String::from_haskell(r#""\EM""#).unwrap(), "\x19");
+        assert_eq!(String::from_haskell(r#""\SUB""#).unwrap(), "\x1A");
+        assert_eq!(String::from_haskell(r#""\ESC""#).unwrap(), "\x1B");
+        assert_eq!(String::from_haskell(r#""\FS""#).unwrap(), "\x1C");
+        assert_eq!(String::from_haskell(r#""\GS""#).unwrap(), "\x1D");
+        assert_eq!(String::from_haskell(r#""\RS""#).unwrap(), "\x1E");
+        assert_eq!(String::from_haskell(r#""\US""#).unwrap(), "\x1F");
+        assert_eq!(String::from_haskell(r#""\SP""#).unwrap(), "\x20");
+        assert_eq!(String::from_haskell(r#""\DEL""#).unwrap(), "\x7F");
+    }
+
+    #[test]
+    fn so_soh_prefix_conflict() {
+        // SOH must match before SO to avoid prefix conflict
+        assert_eq!(String::from_haskell(r#""\SOH""#).unwrap(), "\x01");
+        assert_eq!(String::from_haskell(r#""\SO""#).unwrap(), "\x0E");
+    }
+
+    #[test]
     fn option_from_haskell() {
         assert_eq!(<Option<i32>>::from_haskell("Nothing").unwrap(), None);
         assert_eq!(<Option<u32>>::from_haskell("(Just 42)").unwrap(), Some(42));

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -445,9 +445,15 @@ impl FromHaskell for String {
             match c {
                 '"' => return Ok((result, &rest[1..])),
                 '\\' => {
-                    let (escaped, after) = parse_escape(&rest[1..])?;
-                    result.push(escaped);
-                    rest = after;
+                    if rest[1..].starts_with('&') {
+                        // \& is Haskell's empty escape, used to disambiguate
+                        // named escapes (e.g. "\SO\&H" is SO followed by 'H')
+                        rest = &rest[2..];
+                    } else {
+                        let (escaped, after) = parse_escape(&rest[1..])?;
+                        result.push(escaped);
+                        rest = after;
+                    }
                 }
                 _ => {
                     result.push(c);
@@ -1326,6 +1332,14 @@ mod tests {
         // SOH must match before SO to avoid prefix conflict
         assert_eq!(String::from_haskell(r#""\SOH""#).unwrap(), "\x01");
         assert_eq!(String::from_haskell(r#""\SO""#).unwrap(), "\x0E");
+    }
+
+    #[test]
+    fn empty_escape_disambiguation() {
+        // \& is Haskell's empty escape for disambiguating named escapes
+        // "\SO\&H" is SO (0x0E) followed by 'H', not SOH (0x01)
+        assert_eq!(String::from_haskell(r#""\SO\&H""#).unwrap(), "\x0EH");
+        assert_eq!(String::from_haskell(r#""\NUL\&0""#).unwrap(), "\x000");
     }
 
     #[test]

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -138,6 +138,18 @@ macro_rules! impl_to_haskell_signed {
 
 impl_to_haskell_signed!(i8, i16, i32, i64, i128, isize);
 
+/// Write a float value ensuring a decimal point is always present.
+fn write_float(buf: &mut impl fmt::Write, value: impl fmt::Display) -> fmt::Result {
+    use std::fmt::Write as _;
+    let mut tmp = String::new();
+    write!(tmp, "{value}")?;
+    // Ensure a decimal point so Haskell interprets it as a fractional number
+    if !tmp.contains('.') {
+        tmp.push_str(".0");
+    }
+    buf.write_str(&tmp)
+}
+
 macro_rules! impl_to_haskell_float {
     ($($t:ty),*) => {
         $(impl ToHaskell for $t {
@@ -151,9 +163,11 @@ macro_rules! impl_to_haskell_float {
                         buf.write_str("((-1)/0)")
                     }
                 } else if *self < 0.0 {
-                    write!(buf, "({self:.1})")
+                    buf.write_char('(')?;
+                    write_float(buf, self)?;
+                    buf.write_char(')')
                 } else {
-                    write!(buf, "{self:.1}")
+                    write_float(buf, self)
                 }
             }
         })*
@@ -1102,6 +1116,10 @@ mod tests {
         assert_eq!(f64::NAN.to_haskell(), "(0/0)");
         assert_eq!(f64::INFINITY.to_haskell(), "(1/0)");
         assert_eq!(f64::NEG_INFINITY.to_haskell(), "((-1)/0)");
+        // Precision is preserved
+        assert_eq!(3.14159265358979f64.to_haskell(), "3.14159265358979");
+        assert_eq!((-0.001f64).to_haskell(), "(-0.001)");
+        assert_eq!(1.0f32.to_haskell(), "1.0");
     }
 
     #[test]

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -484,6 +484,44 @@ impl FromHaskell for char {
     }
 }
 
+/// Named ASCII escape sequences produced by Haskell's `show`.
+const NAMED_ESCAPES: &[(&str, char)] = &[
+    ("NUL", '\x00'),
+    ("SOH", '\x01'),
+    ("STX", '\x02'),
+    ("ETX", '\x03'),
+    ("EOT", '\x04'),
+    ("ENQ", '\x05'),
+    ("ACK", '\x06'),
+    ("BEL", '\x07'),
+    ("BS", '\x08'),
+    ("HT", '\x09'),
+    ("LF", '\x0A'),
+    ("VT", '\x0B'),
+    ("FF", '\x0C'),
+    ("CR", '\x0D'),
+    ("SO", '\x0E'),
+    ("SI", '\x0F'),
+    ("DLE", '\x10'),
+    ("DC1", '\x11'),
+    ("DC2", '\x12'),
+    ("DC3", '\x13'),
+    ("DC4", '\x14'),
+    ("NAK", '\x15'),
+    ("SYN", '\x16'),
+    ("ETB", '\x17'),
+    ("CAN", '\x18'),
+    ("EM", '\x19'),
+    ("SUB", '\x1A'),
+    ("ESC", '\x1B'),
+    ("FS", '\x1C'),
+    ("GS", '\x1D'),
+    ("RS", '\x1E'),
+    ("US", '\x1F'),
+    ("SP", '\x20'),
+    ("DEL", '\x7F'),
+];
+
 fn parse_escape(input: &str) -> Result<(char, &str), HaskellParseError> {
     let c = input
         .chars()
@@ -496,6 +534,10 @@ fn parse_escape(input: &str) -> Result<(char, &str), HaskellParseError> {
         'n' => Ok(('\n', &input[1..])),
         't' => Ok(('\t', &input[1..])),
         'r' => Ok(('\r', &input[1..])),
+        'a' => Ok(('\x07', &input[1..])),
+        'b' => Ok(('\x08', &input[1..])),
+        'f' => Ok(('\x0C', &input[1..])),
+        'v' => Ok(('\x0B', &input[1..])),
         '0' => Ok(('\0', &input[1..])),
         c if c.is_ascii_digit() => {
             // Numeric escape: \NNN
@@ -511,6 +553,17 @@ fn parse_escape(input: &str) -> Result<(char, &str), HaskellParseError> {
                 message: format!("invalid unicode code point: {num}"),
             })?;
             Ok((c, &input[end..]))
+        }
+        c if c.is_ascii_uppercase() => {
+            // Named ASCII escapes: \NUL, \SOH, \DEL, etc.
+            for &(name, ch) in NAMED_ESCAPES {
+                if input.starts_with(name) {
+                    return Ok((ch, &input[name.len()..]));
+                }
+            }
+            Err(HaskellParseError::ParseError {
+                message: format!("unknown escape sequence: \\{c}"),
+            })
         }
         _ => Err(HaskellParseError::ParseError {
             message: format!("unknown escape sequence: \\{c}"),

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -557,8 +557,8 @@ fn parse_escape(input: &str) -> Result<(char, &str), HaskellParseError> {
         c if c.is_ascii_uppercase() => {
             // Named ASCII escapes: \NUL, \SOH, \DEL, etc.
             for &(name, ch) in NAMED_ESCAPES {
-                if input.starts_with(name) {
-                    return Ok((ch, &input[name.len()..]));
+                if let Some(rest) = input.strip_prefix(name) {
+                    return Ok((ch, rest));
                 }
             }
             Err(HaskellParseError::ParseError {
@@ -1170,7 +1170,7 @@ mod tests {
         assert_eq!(f64::INFINITY.to_haskell(), "(1/0)");
         assert_eq!(f64::NEG_INFINITY.to_haskell(), "((-1)/0)");
         // Precision is preserved
-        assert_eq!(3.14159265358979f64.to_haskell(), "3.14159265358979");
+        assert_eq!(1.234_567_890_123_456_f64.to_haskell(), "1.234567890123456");
         assert_eq!((-0.001f64).to_haskell(), "(-0.001)");
         assert_eq!(1.0f32.to_haskell(), "1.0");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ pub enum GhciError {
     #[error("Haskell parse error: {0}")]
     HaskellParse(#[from] haskell::HaskellParseError),
     /// Input attempted to change the ghci prompt, which would break the session
+    ///
+    /// Note: this is a best-effort check for direct `:set prompt` commands. Indirect
+    /// changes (e.g. via `:cmd`) are not detected and will break the session.
     #[error("disallowed input: {0}")]
     DisallowedInput(&'static str),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,7 +550,7 @@ impl Ghci {
 
 impl Drop for Ghci {
     fn drop(&mut self) {
-        if let Ok(None) = self.child.try_wait() {
+        if matches!(self.child.try_wait(), Ok(None)) {
             let _ = self.child.kill();
         }
     }
@@ -636,7 +636,10 @@ impl SharedGhci {
 // - the pattern has to be at the end of a given read (otherwise it will hang)
 fn clear_blocking_reader_until(mut r: impl Read, expected_end: &[u8]) -> std::io::Result<()> {
     let pat_len = expected_end.len();
-    assert!(pat_len < 1024, "pattern must be shorter than the read buffer");
+    assert!(
+        pat_len < 1024,
+        "pattern must be shorter than the read buffer"
+    );
     let mut buffer = [0u8; 1024];
     let mut start = 0; // how many bytes at the front are carried over from the previous read
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,18 +613,24 @@ impl SharedGhci {
 // Helper function to clear data from a blocking reader until a pattern is seen
 // - the pattern is also cleared
 // - the pattern has to be at the end of a given read (otherwise it will hang)
-// - limited to 1024 bytes
 fn clear_blocking_reader_until(mut r: impl Read, expected_end: &[u8]) -> std::io::Result<()> {
-    let mut buffer = [0; 1024];
-    let mut end = 0;
+    let pat_len = expected_end.len();
+    assert!(pat_len < 1024, "pattern must be shorter than the read buffer");
+    let mut buffer = [0u8; 1024];
+    let mut start = 0; // how many bytes at the front are carried over from the previous read
     loop {
-        match r.read(&mut buffer[end..]) {
+        match r.read(&mut buffer[start..]) {
             Ok(0) => return Ok(()),
             Ok(bytes) => {
-                end += bytes;
+                let end = start + bytes;
                 if buffer[..end].ends_with(expected_end) {
                     return Ok(());
                 }
+                // Carry over the last pat_len bytes (or fewer if we don't have enough yet)
+                // to the front so the next read appends after them.
+                let keep = pat_len.min(end);
+                buffer.copy_within(end - keep..end, 0);
+                start = keep;
             }
             Err(err) if err.kind() == ErrorKind::Interrupted => {}
             Err(err) => return Err(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,8 +547,8 @@ impl Ghci {
 
 impl Drop for Ghci {
     fn drop(&mut self) {
-        if self.child.try_wait().unwrap().is_none() {
-            self.child.kill().unwrap();
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,4 +746,24 @@ mod tests {
             "expected Timeout, got {res:?}"
         );
     }
+
+    #[test]
+    fn escape_sequences_via_ghci() -> Result<()> {
+        let mut ghci = Ghci::new()?;
+
+        // Ask ghci to show each control character, then parse the result back.
+        // This ensures our parser agrees with ghci's show output.
+        for code_point in (0u32..=31).chain(std::iter::once(127)) {
+            let expr = format!("toEnum {code_point} :: Char");
+            let parsed: char = ghci.eval_as(&expr).unwrap_or_else(|e| {
+                panic!("failed to parse ghci output for code point {code_point}: {e}")
+            });
+            assert_eq!(
+                parsed as u32, code_point,
+                "code point {code_point}: roundtrip mismatch"
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,13 +603,31 @@ impl SharedGhci {
     ///
     /// Panics if the initialization function returns an error or the mutex is poisoned.
     pub fn lock(&self) -> MutexGuard<'_, Ghci> {
-        self.inner
-            .get_or_init(|| {
-                let ghci = (self.init)().expect("SharedGhci initialization failed");
-                Mutex::new(ghci)
-            })
+        self.try_lock()
+            .expect("SharedGhci initialization or lock failed")
+    }
+
+    /// Try to lock and return a guard to the shared ghci session
+    ///
+    /// Initializes the session on first call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the initialization function returns an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`IOError`] if the mutex is poisoned.
+    ///
+    /// [`IOError`]: GhciError::IOError
+    pub fn try_lock(&self) -> Result<MutexGuard<'_, Ghci>> {
+        let mutex = self.inner.get_or_init(|| {
+            let ghci = (self.init)().expect("SharedGhci initialization failed");
+            Mutex::new(ghci)
+        });
+        mutex
             .lock()
-            .expect("SharedGhci mutex poisoned")
+            .map_err(|e| GhciError::IOError(std::io::Error::other(e.to_string())))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,24 +746,4 @@ mod tests {
             "expected Timeout, got {res:?}"
         );
     }
-
-    #[test]
-    fn escape_sequences_via_ghci() -> Result<()> {
-        let mut ghci = Ghci::new()?;
-
-        // Ask ghci to show each control character, then parse the result back.
-        // This ensures our parser agrees with ghci's show output.
-        for code_point in (0u32..=31).chain(std::iter::once(127)) {
-            let expr = format!("toEnum {code_point} :: Char");
-            let parsed: char = ghci.eval_as(&expr).unwrap_or_else(|e| {
-                panic!("failed to parse ghci output for code point {code_point}: {e}")
-            });
-            assert_eq!(
-                parsed as u32, code_point,
-                "code point {code_point}: roundtrip mismatch"
-            );
-        }
-
-        Ok(())
-    }
 }

--- a/tests/ghci_roundtrip.rs
+++ b/tests/ghci_roundtrip.rs
@@ -84,8 +84,10 @@ fn string_with_escapes_roundtrip() {
     roundtrip("quote\"inside".to_string());
     roundtrip("null\0char".to_string());
     roundtrip("\x07bell".to_string());
-    // Strings that trigger \& disambiguation in ghci's show
+    // Strings that trigger \& disambiguation
     roundtrip("\x0EH".to_string()); // SO followed by 'H' (not SOH)
+    roundtrip("\x000".to_string()); // NUL followed by '0'
+    roundtrip("\x011".to_string()); // SOH followed by '1'
 }
 
 // ── Booleans ────────────────────────────────────────────────────────

--- a/tests/ghci_roundtrip.rs
+++ b/tests/ghci_roundtrip.rs
@@ -84,6 +84,8 @@ fn string_with_escapes_roundtrip() {
     roundtrip("quote\"inside".to_string());
     roundtrip("null\0char".to_string());
     roundtrip("\x07bell".to_string());
+    // Strings that trigger \& disambiguation in ghci's show
+    roundtrip("\x0EH".to_string()); // SO followed by 'H' (not SOH)
 }
 
 // ── Booleans ────────────────────────────────────────────────────────

--- a/tests/ghci_roundtrip.rs
+++ b/tests/ghci_roundtrip.rs
@@ -1,0 +1,220 @@
+use ghci::{FromHaskell, Ghci, SharedGhci, ToHaskell};
+
+static GHCI: SharedGhci = SharedGhci::new(Ghci::new);
+
+/// Helper: check both roundtrip directions through ghci.
+///
+/// 1. Rust → ghci → Rust: `to_haskell()` → ghci eval (applies `show`) → `from_haskell` → compare
+/// 2. ghci → Rust → ghci: take ghci's `show` output → `from_haskell` → `to_haskell` → ghci eval → compare with original ghci output
+fn roundtrip<T>(value: T)
+where
+    T: ToHaskell + FromHaskell + PartialEq + std::fmt::Debug,
+{
+    let haskell_expr = value.to_haskell();
+    let mut ghci = GHCI.lock();
+
+    // Direction 1: Rust → ghci → Rust
+    let shown = ghci.eval(&haskell_expr).unwrap_or_else(|e| {
+        panic!("ghci eval failed for {haskell_expr:?}: {e}");
+    });
+    let shown = shown.trim();
+    let parsed = T::from_haskell(shown).unwrap_or_else(|e| {
+        panic!("FromHaskell failed for ghci output {shown:?} (from {haskell_expr:?}): {e}");
+    });
+    assert_eq!(
+        parsed, value,
+        "Rust→ghci→Rust mismatch: {haskell_expr:?} -> {shown:?} -> {parsed:?}"
+    );
+
+    // Direction 2: ghci → Rust → ghci
+    // Re-encode the parsed value and evaluate again — ghci's show output should be stable
+    let re_encoded = parsed.to_haskell();
+    let shown2 = ghci.eval(&re_encoded).unwrap_or_else(|e| {
+        panic!("ghci eval failed for re-encoded {re_encoded:?}: {e}");
+    });
+    assert_eq!(
+        shown2.trim(),
+        shown,
+        "ghci→Rust→ghci mismatch: {shown:?} -> {re_encoded:?} -> {:?}",
+        shown2.trim()
+    );
+}
+
+/// Helper: evaluate a Haskell expression in ghci, parse the shown output, and
+/// compare against an expected Rust value.
+fn eval_roundtrip<T>(expr: &str, expected: T)
+where
+    T: FromHaskell + PartialEq + std::fmt::Debug,
+{
+    let mut ghci = GHCI.lock();
+    let shown = ghci.eval(expr).unwrap_or_else(|e| {
+        panic!("ghci eval failed for {expr:?}: {e}");
+    });
+    let parsed = T::from_haskell(shown.trim()).unwrap_or_else(|e| {
+        panic!("FromHaskell failed for ghci output {shown:?} (from {expr:?}): {e}");
+    });
+    assert_eq!(
+        parsed, expected,
+        "eval_roundtrip mismatch for {expr:?}: {shown:?} -> {parsed:?}"
+    );
+}
+
+// ── Escape sequences ────────────────────────────────────────────────
+
+#[test]
+fn control_char_escapes() {
+    let mut ghci = GHCI.lock();
+    for code_point in (0u32..=31).chain(std::iter::once(127)) {
+        let expr = format!("toEnum {code_point} :: Char");
+        let parsed: char = ghci.eval_as(&expr).unwrap_or_else(|e| {
+            panic!("failed to parse ghci output for code point {code_point}: {e}")
+        });
+        assert_eq!(
+            parsed as u32, code_point,
+            "code point {code_point}: roundtrip mismatch"
+        );
+    }
+}
+
+#[test]
+fn string_with_escapes_roundtrip() {
+    roundtrip("hello\nworld".to_string());
+    roundtrip("tab\there".to_string());
+    roundtrip("back\\slash".to_string());
+    roundtrip("quote\"inside".to_string());
+    roundtrip("null\0char".to_string());
+    roundtrip("\x07bell".to_string());
+}
+
+// ── Booleans ────────────────────────────────────────────────────────
+
+#[test]
+fn bool_roundtrip() {
+    roundtrip(true);
+    roundtrip(false);
+}
+
+// ── Integers ────────────────────────────────────────────────────────
+
+#[test]
+fn unsigned_roundtrip() {
+    roundtrip(0u32);
+    roundtrip(42u32);
+    roundtrip(255u8);
+    roundtrip(u64::MAX);
+}
+
+#[test]
+fn signed_roundtrip() {
+    roundtrip(0i32);
+    roundtrip(42i32);
+    roundtrip(-3i32);
+    roundtrip(i64::MIN);
+    roundtrip(i64::MAX);
+}
+
+#[test]
+fn negative_number_formatting() {
+    // Verify ghci accepts our parenthesized negatives
+    eval_roundtrip::<i32>("(-3)", -3);
+    eval_roundtrip::<i32>("(-127)", -127);
+    // Verify ghci's show output for negatives can be parsed
+    eval_roundtrip::<i32>("negate 42", -42);
+}
+
+// ── Floats ──────────────────────────────────────────────────────────
+
+#[test]
+fn float_precision_roundtrip() {
+    roundtrip(0.0f64);
+    roundtrip(1.0f64);
+    roundtrip(-1.0f64);
+    roundtrip(std::f64::consts::PI);
+    roundtrip(-0.001f64);
+    roundtrip(1e10f64);
+    roundtrip(1.23e-4f64);
+}
+
+#[test]
+fn float_special_values() {
+    // NaN can't use roundtrip (NaN != NaN), test manually
+    let mut ghci = GHCI.lock();
+    let nan_expr = f64::NAN.to_haskell();
+    let shown = ghci.eval(&nan_expr).unwrap();
+    assert_eq!(shown.trim(), "NaN");
+
+    let inf_expr = f64::INFINITY.to_haskell();
+    let shown = ghci.eval(&inf_expr).unwrap();
+    assert_eq!(shown.trim(), "Infinity");
+
+    let neg_inf_expr = f64::NEG_INFINITY.to_haskell();
+    let shown = ghci.eval(&neg_inf_expr).unwrap();
+    assert_eq!(shown.trim(), "-Infinity");
+}
+
+#[test]
+fn float_f32_roundtrip() {
+    roundtrip(0.0f32);
+    roundtrip(1.0f32);
+    roundtrip(-1.5f32);
+    roundtrip(std::f32::consts::PI);
+}
+
+// ── Strings and chars ───────────────────────────────────────────────
+
+#[test]
+fn string_roundtrip() {
+    roundtrip(String::new());
+    roundtrip("hello world".to_string());
+    roundtrip("with spaces and 123 numbers".to_string());
+}
+
+#[test]
+fn char_roundtrip() {
+    roundtrip('x');
+    roundtrip(' ');
+    roundtrip('\'');
+    roundtrip('\\');
+    roundtrip('"');
+    roundtrip('\n');
+}
+
+// ── Option ──────────────────────────────────────────────────────────
+
+#[test]
+fn option_roundtrip() {
+    roundtrip(None::<i32>);
+    roundtrip(Some(42i32));
+    roundtrip(Some(-3i32));
+    roundtrip(Some("hello".to_string()));
+}
+
+// ── Vec ─────────────────────────────────────────────────────────────
+
+#[test]
+fn vec_roundtrip() {
+    roundtrip(Vec::<i32>::new());
+    roundtrip(vec![1i32, 2, 3]);
+    roundtrip(vec![-1i32, 0, 1]);
+    roundtrip(vec!["hello".to_string(), "world".to_string()]);
+}
+
+// ── Tuples ──────────────────────────────────────────────────────────
+
+#[test]
+fn tuple_roundtrip() {
+    roundtrip((1u32, true));
+    roundtrip((1u32, 2u32, 3u32));
+    roundtrip(("hello".to_string(), 42i32));
+    roundtrip((true, false, true, false));
+}
+
+// ── Nested types ────────────────────────────────────────────────────
+
+#[test]
+fn nested_roundtrip() {
+    roundtrip(Some(vec![1i32, -2, 3]));
+    roundtrip(vec![Some(1i32), None, Some(3)]);
+    roundtrip(vec![(1u32, true), (2, false)]);
+    roundtrip(Some((42i32, "hello".to_string())));
+}


### PR DESCRIPTION
## Summary

- Fix float `ToHaskell` truncating to 1 decimal place (data loss bug)
- Fix `Drop` impl panicking on unexpected child process state
- Fix `clear_blocking_reader_until` buffer overflow on large ghci startup output
- Handle all Haskell escape sequences in `FromHaskell` parser (`\a`, `\b`, `\f`, `\v`, `\NUL`, `\DEL`, etc.)
- Document that `:set prompt` detection is best-effort (bypassable via `:cmd`)
- Add `SharedGhci::try_lock()` as fallible alternative to `lock()`
- Expand README with feature overview (type conversions, derive macros, builder, timeouts, shared sessions)
- Update CHANGELOG for 0.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)