### PR TITLE
Add ghci! proc macro in its own ghci-macros crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "ghci-derive"]
+members = [".", "ghci-derive", "ghci-macros"]
 
 [package]
 name = "ghci"
@@ -14,12 +14,14 @@ categories = ["compilers", "development-tools"]
 
 [features]
 derive = ["dep:ghci-derive"]
+macros = ["dep:ghci-macros"]
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["poll"], default-features = false }
 nonblock = "0.2"
 thiserror = "2"
 ghci-derive = { version = "0.2.1", path = "ghci-derive", optional = true }
+ghci-macros = { version = "0.2.1", path = "ghci-macros", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
@@ -27,3 +29,7 @@ version-sync = "0.9"
 [[test]]
 name = "derive"
 required-features = ["derive"]
+
+[[test]]
+name = "ghci_macro"
+required-features = ["macros"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@ struct Pair(u32, bool);
 
 See the [derive macro docs](https://docs.rs/ghci-derive) for all supported attributes (`name`, `transparent`, `style`, `skip`, `bound`).
 
+### Inline Haskell with `ghci!`
+
+With the `macros` feature, use the `ghci!` macro to write inline Haskell expressions and inject Rust values as let-bindings:
+
+```rust
+use ghci::{ghci, Ghci, ToHaskell};
+
+let mut ghci = Ghci::new()?;
+ghci.import(&["Data.Char"])?;
+
+// Simple expression
+let n: i32 = ghci!(&mut ghci, { length "hello" })?;
+assert_eq!(n, 5);
+
+// Inject Rust values as Haskell bindings
+let name = "world".to_string();
+let greeting: String = ghci!(&mut ghci, [name] { map toUpper name })?;
+assert_eq!(greeting, "WORLD");
+
+// Bind with a different Haskell name
+let items: Vec<i32> = vec![3, 1, 4, 1, 5];
+let sorted: Vec<i32> = ghci!(&mut ghci, [xs = items] { sort xs })?;
+assert_eq!(sorted, vec![1, 1, 3, 4, 5]);
+```
+
 ### Configuration
 
 Use `GhciBuilder` to configure the ghci session:

--- a/ghci-macros/Cargo.toml
+++ b/ghci-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ghci-macros"
+version = "0.2.1"
+repository = "https://github.com/basile-henry/ghci-rs"
+authors = ["Basile Henry <bjm.henry@gmail.com>"]
+license = "MIT"
+edition = "2021"
+description = "Proc macros for inline Haskell evaluation via ghci"
+readme = "../README.md"
+keywords = ["haskell", "repl", "subprocess", "ffi"]
+categories = ["compilers", "development-tools"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/ghci-macros/src/lib.rs
+++ b/ghci-macros/src/lib.rs
@@ -1,0 +1,132 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, Expr, Ident, Token};
+
+struct Binding {
+    haskell_name: Ident,
+    rust_expr: Expr,
+}
+
+impl Parse for Binding {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let haskell_name: Ident = input.parse()?;
+        let rust_expr = if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            // Use Expr::parse_without_eager_brace to avoid consuming past commas in
+            // brackets. However, Expr parsing is still greedy, so wrap non-trivial
+            // expressions in parentheses: [z = (1 + 2)]
+            Expr::parse_without_eager_brace(input)?
+        } else {
+            syn::parse_quote!(#haskell_name)
+        };
+        Ok(Binding {
+            haskell_name,
+            rust_expr,
+        })
+    }
+}
+
+struct GhciMacroInput {
+    ghci_expr: Expr,
+    bindings: Vec<Binding>,
+    body: TokenStream2,
+}
+
+impl Parse for GhciMacroInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ghci_expr: Expr = input.parse()?;
+        input.parse::<Token![,]>()?;
+
+        let bindings = if input.peek(syn::token::Bracket) {
+            let content;
+            syn::bracketed!(content in input);
+            let bindings = content.parse_terminated(Binding::parse, Token![,])?;
+            bindings.into_iter().collect()
+        } else {
+            Vec::new()
+        };
+
+        let body_content;
+        syn::braced!(body_content in input);
+        let body: TokenStream2 = body_content.parse()?;
+
+        Ok(GhciMacroInput {
+            ghci_expr,
+            bindings,
+            body,
+        })
+    }
+}
+
+fn expand_ghci(input: GhciMacroInput) -> TokenStream2 {
+    let ghci_expr = &input.ghci_expr;
+    let body_str = input.body.to_string();
+
+    if input.bindings.is_empty() {
+        quote! {
+            {
+                ::ghci::Ghci::eval_as(#ghci_expr, #body_str)
+            }
+        }
+    } else {
+        let mut stmts = Vec::new();
+        stmts.push(quote! {
+            let mut __ghci_expr = ::std::string::String::new();
+        });
+
+        for (i, binding) in input.bindings.iter().enumerate() {
+            let name = binding.haskell_name.to_string();
+            let rust_expr = &binding.rust_expr;
+            if i > 0 {
+                stmts.push(quote! {
+                    __ghci_expr.push_str(" in ");
+                });
+            }
+            stmts.push(quote! {
+                __ghci_expr.push_str(concat!("let ", #name, " = "));
+                __ghci_expr.push_str(&::ghci::ToHaskell::to_haskell(&#rust_expr));
+            });
+        }
+
+        stmts.push(quote! {
+            __ghci_expr.push_str(concat!(" in ", #body_str));
+        });
+
+        quote! {
+            {
+                #(#stmts)*
+                ::ghci::Ghci::eval_as(#ghci_expr, &__ghci_expr)
+            }
+        }
+    }
+}
+
+/// Evaluate an inline Haskell expression via a GHCi session.
+///
+/// # Syntax
+///
+/// ```rust,ignore
+/// // No bindings:
+/// ghci!(&mut ghci, { 1 + 2 })
+///
+/// // With bindings (Rust vars injected as Haskell let-bindings):
+/// ghci!(&mut ghci, [x, y] { x ++ " " ++ y })
+///
+/// // Expression bindings:
+/// ghci!(&mut ghci, [z = some_expr] { z * 10 })
+/// ```
+///
+/// Returns `Result<T>` where `T` is inferred from context (via `FromHaskell`).
+///
+/// # Known limitations
+///
+/// - Backtick application (`` x `div` y ``) is not supported — use `div x y` instead
+/// - Primed identifiers (`x'`, `f'`) are not supported — `'` starts a lifetime/char token in Rust
+/// - Haskell-specific escape sequences in string literals that differ from Rust
+#[proc_macro]
+pub fn ghci(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as GhciMacroInput);
+    expand_ghci(input).into()
+}

--- a/ghci-macros/src/lib.rs
+++ b/ghci-macros/src/lib.rs
@@ -37,6 +37,12 @@ struct GhciMacroInput {
 impl Parse for GhciMacroInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let ghci_expr: Expr = input.parse()?;
+        // Normalize: wrap with &mut if not already a mutable reference, so both
+        // `ghci` and `&mut ghci` are accepted in addition to `&mut *ghci`.
+        let ghci_expr = match &ghci_expr {
+            Expr::Reference(r) if r.mutability.is_some() => ghci_expr,
+            _ => syn::parse_quote!(&mut #ghci_expr),
+        };
         input.parse::<Token![,]>()?;
 
         let bindings = if input.peek(syn::token::Bracket) {
@@ -109,14 +115,18 @@ fn expand_ghci(input: GhciMacroInput) -> TokenStream2 {
 ///
 /// ```rust,ignore
 /// // No bindings:
-/// ghci!(&mut ghci, { 1 + 2 })
+/// ghci!(ghci, { 1 + 2 })
 ///
 /// // With bindings (Rust vars injected as Haskell let-bindings):
-/// ghci!(&mut ghci, [x, y] { x ++ " " ++ y })
+/// ghci!(ghci, [x, y] { x ++ " " ++ y })
 ///
 /// // Expression bindings:
-/// ghci!(&mut ghci, [z = some_expr] { z * 10 })
+/// ghci!(ghci, [z = some_expr] { z * 10 })
 /// ```
+///
+/// The first argument is always taken by mutable reference internally. Passing
+/// `ghci`, `&mut ghci`, or `&mut *ghci` (for a dereffed smart pointer) are all
+/// accepted.
 ///
 /// Returns `Result<T>` where `T` is inferred from context (via `FromHaskell`).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub use haskell::{FromHaskell, HaskellParseError, ToHaskell};
 #[cfg(feature = "derive")]
 pub use ghci_derive::{FromHaskell, ToHaskell};
 
+#[cfg(feature = "macros")]
+pub use ghci_macros::ghci;
+
 /// A ghci session handle
 ///
 /// The session is stateful, so the order of interaction matters

--- a/tests/ghci_macro.rs
+++ b/tests/ghci_macro.rs
@@ -1,0 +1,85 @@
+use ghci::{ghci, Ghci, SharedGhci};
+
+static GHCI: SharedGhci = SharedGhci::new(|| {
+    let mut ghci = Ghci::new()?;
+    ghci.import(&["Data.Char", "Data.List"])?;
+    Ok(ghci)
+});
+
+#[test]
+fn simple_arithmetic() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let out: i32 = ghci!(&mut *ghci, { 1 + 2 })?;
+    assert_eq!(out, 3);
+    Ok(())
+}
+
+#[test]
+fn string_concat_with_bindings() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let x = "hello".to_string();
+    let y = "world".to_string();
+    let out: String = ghci!(&mut *ghci, [x, y] { x ++ " " ++ y })?;
+    assert_eq!(out, "hello world");
+    Ok(())
+}
+
+#[test]
+fn haskell_dollar_operator() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let out: i32 = ghci!(&mut *ghci, { succ $ 2 })?;
+    assert_eq!(out, 3);
+    Ok(())
+}
+
+#[test]
+fn haskell_dot_operator() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let out: i32 = ghci!(&mut *ghci, { (succ . succ) 1 })?;
+    assert_eq!(out, 3);
+    Ok(())
+}
+
+#[test]
+fn list_operations_with_bindings() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let xs: Vec<i32> = vec![1, 2, 3];
+    let out: Vec<i32> = ghci!(&mut *ghci, [xs] { map (* 2) xs })?;
+    assert_eq!(out, vec![2, 4, 6]);
+    Ok(())
+}
+
+#[test]
+fn expression_binding() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let out: i32 = ghci!(&mut *ghci, [z = (1i32 + 2)] { z * 10 })?;
+    assert_eq!(out, 30);
+    Ok(())
+}
+
+#[test]
+fn bool_result() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let out: bool = ghci!(&mut *ghci, { True && False })?;
+    assert!(!out);
+    Ok(())
+}
+
+#[test]
+fn single_binding() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let n: i32 = 42;
+    let out: i32 = ghci!(&mut *ghci, [n] { n + 1 })?;
+    assert_eq!(out, 43);
+    Ok(())
+}
+
+#[test]
+fn binding_with_method_call() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    let items = [10i32, 20, 30];
+    let n = items.len() as i32;
+    let out: String = ghci!(&mut *ghci, [n] { show n })?;
+    assert_eq!(out, "3");
+    Ok(())
+}

--- a/tests/ghci_macro.rs
+++ b/tests/ghci_macro.rs
@@ -9,7 +9,7 @@ static GHCI: SharedGhci = SharedGhci::new(|| {
 #[test]
 fn simple_arithmetic() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
-    let out: i32 = ghci!(&mut *ghci, { 1 + 2 })?;
+    let out: i32 = ghci!(ghci, { 1 + 2 })?;
     assert_eq!(out, 3);
     Ok(())
 }
@@ -19,7 +19,7 @@ fn string_concat_with_bindings() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
     let x = "hello".to_string();
     let y = "world".to_string();
-    let out: String = ghci!(&mut *ghci, [x, y] { x ++ " " ++ y })?;
+    let out: String = ghci!(ghci, [x, y] { x ++ " " ++ y })?;
     assert_eq!(out, "hello world");
     Ok(())
 }
@@ -27,7 +27,7 @@ fn string_concat_with_bindings() -> ghci::Result<()> {
 #[test]
 fn haskell_dollar_operator() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
-    let out: i32 = ghci!(&mut *ghci, { succ $ 2 })?;
+    let out: i32 = ghci!(ghci, { succ $ 2 })?;
     assert_eq!(out, 3);
     Ok(())
 }
@@ -35,7 +35,7 @@ fn haskell_dollar_operator() -> ghci::Result<()> {
 #[test]
 fn haskell_dot_operator() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
-    let out: i32 = ghci!(&mut *ghci, { (succ . succ) 1 })?;
+    let out: i32 = ghci!(ghci, { (succ . succ) 1 })?;
     assert_eq!(out, 3);
     Ok(())
 }
@@ -44,7 +44,7 @@ fn haskell_dot_operator() -> ghci::Result<()> {
 fn list_operations_with_bindings() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
     let xs: Vec<i32> = vec![1, 2, 3];
-    let out: Vec<i32> = ghci!(&mut *ghci, [xs] { map (* 2) xs })?;
+    let out: Vec<i32> = ghci!(ghci, [xs] { map (* 2) xs })?;
     assert_eq!(out, vec![2, 4, 6]);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn list_operations_with_bindings() -> ghci::Result<()> {
 #[test]
 fn expression_binding() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
-    let out: i32 = ghci!(&mut *ghci, [z = (1i32 + 2)] { z * 10 })?;
+    let out: i32 = ghci!(ghci, [z = (1i32 + 2)] { z * 10 })?;
     assert_eq!(out, 30);
     Ok(())
 }
@@ -60,7 +60,7 @@ fn expression_binding() -> ghci::Result<()> {
 #[test]
 fn bool_result() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
-    let out: bool = ghci!(&mut *ghci, { True && False })?;
+    let out: bool = ghci!(ghci, { True && False })?;
     assert!(!out);
     Ok(())
 }
@@ -69,7 +69,7 @@ fn bool_result() -> ghci::Result<()> {
 fn single_binding() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
     let n: i32 = 42;
-    let out: i32 = ghci!(&mut *ghci, [n] { n + 1 })?;
+    let out: i32 = ghci!(ghci, [n] { n + 1 })?;
     assert_eq!(out, 43);
     Ok(())
 }
@@ -79,7 +79,16 @@ fn binding_with_method_call() -> ghci::Result<()> {
     let mut ghci = GHCI.lock();
     let items = [10i32, 20, 30];
     let n = items.len() as i32;
-    let out: String = ghci!(&mut *ghci, [n] { show n })?;
+    let out: String = ghci!(ghci, [n] { show n })?;
     assert_eq!(out, "3");
+    Ok(())
+}
+
+#[test]
+fn explicit_mut_ref() -> ghci::Result<()> {
+    let mut ghci = GHCI.lock();
+    // &mut ghci and &mut *ghci are also accepted
+    let out: i32 = ghci!(&mut *ghci, { 7 })?;
+    assert_eq!(out, 7);
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Introduces a new `ghci-macros` crate containing the `ghci!` proc macro for inline Haskell evaluation
- Adds a `macros` feature flag in the root crate, separate from the `derive` feature
- Adds a README section with `ghci!` usage examples

```rust
let name = "world".to_string();
let greeting: String = ghci!(&mut ghci, [name] { map toUpper name })?;
assert_eq!(greeting, "WORLD");

// Bind with a different Haskell name
let items: Vec<i32> = vec![3, 1, 4, 1, 5];
let sorted: Vec<i32> = ghci!(&mut ghci, [xs = items] { sort xs })?;
assert_eq!(sorted, vec![1, 1, 3, 4, 5]);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)