### PR TITLE
Run CI test and clippy with --workspace --all-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,6 @@ on:
       - main
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -21,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+      - run: cargo test --workspace --all-features
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

- Remove redundant `check` job (already covered by `test`)
- CI `test` job now uses `--workspace --all-features` so all crates and feature-gated tests are covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)